### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/01基础知识(Basic Knowledge)/01.What-is-Cordova.md
+++ b/01基础知识(Basic Knowledge)/01.What-is-Cordova.md
@@ -1,19 +1,19 @@
-#Cordova
-##Cordova由来
+# Cordova
+## Cordova由来
 很多开发者有很多误解，什么叫Cordova,什么叫PhoneGap，他们之间有哪些区别。谈到这个问题不得不说cordova的发展历史。那是在2008年8月，PhoneGap在旧金山举办的iPhoneDevCamp上崭露头角，起名为PhoneGap是创始人的想法：“为跨越Web技术和iPhone之间的鸿沟牵线搭桥”。当时PhoneGap隶属于Nitobe公司,而从Nitobe的博客上你可以看到最初创作者对他的评价“他有点像为iphone而开发的AIR”(Air桌面技术使得web开发人员使用HTML,CSS,Javascript开发桌面应用程序)。2009年2月25日，PhoneGap0.6发布，是PhoneGap历史上第一个稳定版本，分别支持IOS,Android,BlackBerry平台。在那个时候，PhoneGap已经决定了它所担当的历史任务，直到现在。慢慢的PhoneGap开始支持更多平台。而在此时，被乔布斯宣布死亡的Flash持有者adobe开始意识到，这个项目似乎是自己放弃Flash而寻找替代的一个产品。于是2011年10月4日，Adobe宣布收购Nitobe,在收购之后Adobe其实并没有做太多的贡献，只是把原来的PhoneGap和PhoneGap Build 提供服务并做好宣传工作。
 
 后来Adobe将Phonegap捐献给Apache基金会，作为开源项目。但项目初期依然只是Adobe公司内部员工来维护该项目，而由于Adobe公司依然保留着PhoneGap的商标所有权，导致在那以后的一段日子里，PhoneGap一直被认为是Adobe公司的私有财产。直到PhoneGap1.4发布时，Cordova这个名字才真正被Apache公布（期间有过一次更名叫Apache Callback）。看到这段历史你可能会想到另一端历史Javascript和ECMAscript，你会发现Cordova之于PhoneGap和ECMAscript之于Javascript是多么的相似。
 ![image](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/cordovaapparchitecture.png)
-###Cordova和PhoneGap到底都是指什么？
+### Cordova和PhoneGap到底都是指什么？
 * 从概念上将 Cordova是Adobe捐献给Apache的项目，是一个开源的、核心的跨平台模块。而PhoneGap是Adobe的一项商业产品，有自己的商业版权，有自己平台服务，有自己的收费项目。
 * Cordova和PhoneGap的关系就类似于WebKit与Chrome的关系,类似于ECMAscript和Javascript的关系。
 * PhoneGap作为商用组件，还包括一些PhoneGap Build和Adobe Shadow等商业服务。
 * 然而Cordova和PhoneGap的核心代码是一样的。
 
-###Adobe公司为什么要捐献这个项目？
+### Adobe公司为什么要捐献这个项目？
 其实在收购Nitobe公司的时候就已经做定主意将PhoneGap开源，具体原因也许只能是Adobe的高层才能解释，我理解是当时Adobe Flash的挫败使得Adobe必须有一个时代的替代品，而PhoneGap就是这么一个产品，所以Adobe不准备在核心代码上做文章，而是通过收费的PhoneGap build和Adobe Shadow来占领市场，将PhoneGap开源能够保证框架的大面积推广，说到底他们不想浪费时间来维护更新这个项目
 
-##Cordova现状
+## Cordova现状
 * 最新已经有version6.x,核心代码稳定，更新快速，平台支持较多（我记得PhoneGap最猖狂的时候支持11个平台，现在是8个），平台多不一定是好事，因为核心要兼容多平台，那通用接口就会少，就个人而言最理想的是支持5个平台左右为宜。
 * 同类型竞品多。不过像Cordova相同的角色到并没有，作为hybrid开发中间件，其实有很多竞品。你可以看到和Phonegap几乎同时出道的老大哥Titanium，其实更倾向于将javascript打造成编译语言的角色，而同Titanium类型相近的有国内的Dcloud等。而在最初国内有一款叫Appcan的框架在前些日子也宣布全面开源了，但是你知道的国内的开源都是耍着流氓立牌坊的，免费并不代表开源，所以Cordova充当的角色在一段时期内还是无人能替代的。
 * 瓶颈在于性能。由于Cordova的实现借助浏览器核心webkit，而javascript的低性能导致由Cordova开发出的应用性能一直是其他开发者大喷特喷的一点，不过新的技术革新，这个问题在逐渐被改观。

--- a/01基础知识(Basic Knowledge)/03Install Cordova(Cordova的安装).md
+++ b/01基础知识(Basic Knowledge)/03Install Cordova(Cordova的安装).md
@@ -1,21 +1,21 @@
 翻译自cordova官方文档（如果需要链接，请自行对照原文链接进行查看）： <br>
 https://cordova.apache.org/#getstarted<br>
 
-###1. 安装Cordova
+### 1. 安装Cordova
 Cordova是通过运行在Nodejs的NPM工具安装的,通过后面的添加平台相关内容安装对应的平台依赖.
 打开命令行窗口输入命令:
 ```sh
 $ npm install -g cordova
 ```
 
-###2 创建Cordova工程
+### 2 创建Cordova工程
 通过Cordova的命令行工具创建一个Cordova空工程,进入到你希望的工程文件夹根目录输入如下命令:
 ```sh
 $ cordova create MyApp
 ```
 获取更多帮助信息可以输入 [cordova help create] 指令<br>
 
-###3 添加平台(指创建对应的手机环境)
+### 3 添加平台(指创建对应的手机环境)
 在创建完Cordova项目以后,进入到项目根目录,在此通过下面的指令添加你需要生成对应的app的平台.
 输入 [cordova platform add <platform name>]添加对应的app平台,而后通过[cordova run <platform name>]运行你的app.
 ```sh

--- a/01基础知识(Basic Knowledge)/04.Cordova Command-Line-Interface(Cordova命令行).md
+++ b/01基础知识(Basic Knowledge)/04.Cordova Command-Line-Interface(Cordova命令行).md
@@ -1,10 +1,10 @@
 翻译自cordova官方文档（如果需要链接，请自行对照原文链接进行查看）： <br>
 https://cordova.apache.org/docs/en/6.x/guide/cli/index.html<br>
 
-##Cordova命令行
+## Cordova命令行
 本章主要介绍如何使用Cordova的命令行工具(Command-Line-Interface)
 
-####前提条件
+#### 前提条件
 首先在运行任何命令之前,需要安装对应平台的SDK，目前Cordova支持的开发平台主要有以下几个平台:
 
 ```html
@@ -16,7 +16,7 @@ https://cordova.apache.org/docs/en/6.x/guide/cli/index.html<br>
     Windows (Windows)
     Firefox OS (Mac, Linux, Windows)
 ```
-####安装Cordova
+#### 安装Cordova
 首先需要安装Nodejs环境，然后安装npm，然后使用命令:
 Mac&Linux
 ```sh
@@ -39,7 +39,7 @@ Windows<br>
     $ cordova -v  # 6.0.0
 ```
 
-####创建应用程序工程
+#### 创建应用程序工程
 命令语法：$ cordova create project_path com.project.appname appname
 ```sh
     $ cordova create CordovaCn com.cordovacn CordovaCnApp
@@ -53,7 +53,7 @@ Windows<br>
      ******************************************************************/
 ```
 
-####添加平台
+#### 添加平台
 添加平台首先要进入到你创建的Cordova工程根目录，比如：
 ```sh
     $ cd CordovaCn
@@ -83,7 +83,7 @@ Windows<br>
      ****************************************************************/
 ```
 
-####工程目录结构说明
+#### 工程目录结构说明
 ```sh
 myapp/
     |-- config.xml # cordova的核心配置文件，在下一章节进行详细说明<br>
@@ -95,14 +95,14 @@ myapp/
     -- plugins/ # 安装插件的时候，会将插件的原始代码存放到此文件夹。大家在使用插件遇到问题的时候，请到这个目录查找readme文件<br>
 ```
 
-####删除不需要的平台
+#### 删除不需要的平台
 ```sh
     $ cordova platform remove blackberry10
     $ cordova platform rm amazon-fireos
     $ cordova platform rm android
 ```
 
-####检查哪些移动平台的镜像可以更新
+#### 检查哪些移动平台的镜像可以更新
 ```sh
     $ cordova platform check
     #Creating Cordova project for the Android platform:
@@ -116,14 +116,14 @@ myapp/
     #当前生成的android工程镜像是使用的4.1.1，可以被更新。
 ```
 
-####升级特定平台的镜像版本
+#### 升级特定平台的镜像版本
 ```sh
     $ cordova platform update android
     $ cordova platform update ios
     ...etc.
 ```
 
-####构建应用程序
+#### 构建应用程序
 可以通过以下的命令进行对工程的构建操作
 ```sh
     $ cordova build
@@ -141,13 +141,13 @@ myapp/
     $ cordova prepare ios
 ```
 
-####在模拟器测试
+#### 在模拟器测试
 ```sh
     $ cordova emulate android
 ```
 *从我个人建议，我是并不建议通过Cordova的指令来对app进行调试和运行的。我还是建议使用特定平台的开发工具来进行此类操作比如Android studio,XCode,Eclipse等。*
 
-####在设备运行app
+#### 在设备运行app
 ```sh
     $ cordova run android
 ```
@@ -159,16 +159,16 @@ myapp/
 
 *emulate,build和run命令需要一些环境配置，所以对于很多人来说经常会遇到很多麻烦。这里我还是建议大家尽可能使用Android或者ios等特定平台的指定开发工具进行调试和运行。比如Android Studio或者XCode*
 
-##插件相关的命令
+## 插件相关的命令
 Cordova的插件(plugin)是Cordova为web提供的与移动平台原生api交互的桥梁，而在Cordova官方已经为大家提供了非常丰富的plugin来使用，一般情况下是不需要自己单独开发的。
-####如何查找插件
+#### 如何查找插件
 当你需要一个功能插件的时候，但是又不知道叫什么名字，可以通过如下命令来查找你需要的插件：
 ```sh
     $ cordova plugin search bar code
     // com.phonegap.plugins.barcodescanner - Scans Barcodes
     // cordova-plugin-statusbar - Cordova StatusBar Plugin
 ```
-####如何安装插件
+#### 如何安装插件
 通过cordova plugin add我们可以到指定的库或者目录去安装指定的插件，下面是apache已经提供的一些基本的功能插件
 ```sh
     //基本设备信息
@@ -206,24 +206,24 @@ Cordova的插件(plugin)是Cordova为web提供的与移动平台原生api交互�
     $ cordova plugin add cordova-plugin-console
 ```
 
-####查看当前安装的plugin
+#### 查看当前安装的plugin
 ```sh
     $ cordova plugin ls # or 'plugin list'
 ```
  
-####删除plugin
+#### 删除plugin
 ```sh
     $ cordova plugin rm cordova-plugin-console
     $ cordova plugin remove cordova-plugin-console
 ```
 
-####安装指定Version的插件
+#### 安装指定Version的插件
 ```sh
     $ cordova plugin add cordova-plugin-console@latest
     $ cordova plugin add cordova-plugin-console@0.2.1
 ```
 
-####安装指定位置或库的插件
+#### 安装指定位置或库的插件
 ```sh
     $ cordova plugin add https://github.com/apache/cordova-plugin-console.git
     $ cordova plugin add https://github.com/apache/cordova-plugin-console.git#r0.2.0
@@ -233,7 +233,7 @@ Cordova的插件(plugin)是Cordova为web提供的与移动平台原生api交互�
     $ cordova plugin add https://github.com/someone/aplugin.git#r0.0.1:/my/sub/dir
     $ cordova plugin add ../my_plugin_dir
 ```
-####merges目录(我尝试在最新版本cordova使用该文件夹已经不起作用，后来问度娘说是新版本已经取消了使用hooks替代)
+#### merges目录(我尝试在最新版本cordova使用该文件夹已经不起作用，后来问度娘说是新版本已经取消了使用hooks替代)
 在工程根目录下创建merges目录结构如下：
 ```sh
 merges
@@ -242,7 +242,7 @@ merges
 ```
 *里面存放的文件，当rebuild的时候不会被根目录www目录下的文件所覆盖,这样就可以保留针对特定平台而使用的css，js，html而不用每次build后回滚代码了。*
 
-####命令帮助
+#### 命令帮助
 ```sh
     $ cordova help
     $ cordova        # same
@@ -250,7 +250,7 @@ merges
     $ cordova info # 查看cordova命令的详细
 ```
 
-####更新Cordova
+#### 更新Cordova
 ```sh
     $ sudo npm update -g cordova
     $ sudo npm install -g cordova@3.1.0-0.2.0 # 升级到指定版本

--- a/01基础知识(Basic Knowledge)/05.config.xml Guide(config.xml指南).md
+++ b/01基础知识(Basic Knowledge)/05.config.xml Guide(config.xml指南).md
@@ -1,7 +1,7 @@
 翻译自cordova官方文档（如果需要链接，请自行对照原文链接进行查看）： 
 https://cordova.apache.org/docs/en/latest/config_ref/index.html
 
-##config.xml的作用
+## config.xml的作用
 Config.xml用于控制一些app的行为，这个平台无关的xml文件是基于W3C的Packaged Web Apps(Widgets)描述标准，扩充特定的核心Cordova API功能，插件和特定平台设置<br>
 
 当通过Cordova命令行创建一个工程以后，在其根目录会有一个config.xml文件,当使用platform add命令添加指定的移动平台以后，会在platforms目录各自平台的子目录有一个config.xml的拷贝<br>
@@ -11,7 +11,7 @@ Config.xml用于控制一些app的行为，这个平台无关的xml文件是基�
     app/platforms/android/res/xml/config.xml
 ```
 
-##config.xml核心配置元素
+## config.xml核心配置元素
 ```sh
     <widget id="com.example.hello" version="0.0.1">
         <name>HelloWorld</name>
@@ -32,13 +32,13 @@ Config.xml用于控制一些app的行为，这个平台无关的xml文件是基�
 <access>此配置用来设置app可以访问哪些外部域下server的资源，具体参考Whitelist<br>
 <preference>用于设置各个可选设置，每一个preference不区分大小写，有一些preference只针对特殊平台有效。下面是一些针对多平台有效的常见preference。<br>
 
-##共通参数
+## 共通参数
 该参数用于设置app是否隐藏状态栏，在ios下是不隐藏状态栏的，但是会影响获取状态栏高度的准确值，默认为false。
 ```html
     <preference name="Fullscreen" value="true" />
 ```
 
-##支持多平台的参数设置
+## 支持多平台的参数设置
 设置是否禁止滑动超出范围，此时会在超出部分显示黑色背景。在ios下如果设置为true，会引起拖拽页面的时候会触发放大显示功能。
 ```html
     <preference name="DisallowOverscroll" value="true"/>     #仅支持IOS&Android
@@ -87,7 +87,7 @@ Config.xml用于控制一些app的行为，这个平台无关的xml文件是基�
     <hook type="after_plugin_install" src="scripts/afterPluginInstall.js" />
 ```
 
-##iOS的config.xml设置
+## iOS的config.xml设置
 EnableViewportScale (boolean, defaults to false) 如果设置成true，用于在viewport的meta标签是否生效。
 ```html
     <preference name="EnableViewportScale" value="true"/>
@@ -222,7 +222,7 @@ CDVSystemSchemesOverride (string, defaults to maps,tel,telprompt) 设置允许�
     <preference name="CDVSystemSchemesOverride" value="maps,tel,telprompt" />
 ```
 
-##Android的config.xml设置
+## Android的config.xml设置
 KeepRunning (boolean, defaults to true): 决定是否允许app在pause后依然运行，设置成false在app接受pause的时候就不会被杀死了，只是暂停执行代码
 ```html
     <preference name="KeepRunning" value="false"/>

--- a/01基础知识(Basic Knowledge)/06.Customize Icons(自定义图标).md
+++ b/01基础知识(Basic Knowledge)/06.Customize Icons(自定义图标).md
@@ -2,7 +2,7 @@
 https://cordova.apache.org/docs/en/latest/config_ref/images.html
 
 *由于新版本的Documentation把Splashscreen部分转移到Splashscreen plugin docs里面去了。所以这里就只介绍Icions了*
-##自定义App图标
+## 自定义App图标
 开发者可以通过config.xml文件的<icon>元素来设置app的图标，如果没有指定图标的话，会采用Apache Cordova logo作为默认图标。
 
 ```xml

--- a/01基础知识(Basic Knowledge)/07.Event(事件).md
+++ b/01基础知识(Basic Knowledge)/07.Event(事件).md
@@ -1,9 +1,9 @@
 翻译自cordova官方文档（如果需要链接，请自行对照原文链接进行查看）： 
 https://cordova.apache.org/docs/en/latest/cordova/events/events.html
 
-##Event(事件)
+## Event(事件)
 这里介绍Cordova提供的在App中可以使用的各种事件。在App中可以通过listener的方式监听并响应这些事件，对这些事件进行处理。下面是一个Demo:
-###HTML File
+### HTML File
 ```html
 	<!DOCTYPE html>
 	<html>
@@ -17,7 +17,7 @@ https://cordova.apache.org/docs/en/latest/cordova/events/events.html
 	  </body>
 	</html>
 ```
-###JS File
+### JS File
 ```JavaScript
 	// example.js file
 	// Wait for device API libraries to load
@@ -50,10 +50,10 @@ https://cordova.apache.org/docs/en/latest/cordova/events/events.html
 	// Add similar event handlers for other events
 ```
 
-###下面是目前各个平台对事件的支持情况
+### 下面是目前各个平台对事件的支持情况
 ![](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/Screen%20Shot%202016-03-10%20at%20%E4%B8%8A%E5%8D%8811.34.44.png)
 
-####deviceready
+#### deviceready
 deviceready事件是在Cordova完全加载以后发出的。这个事件代表着Cordova的APIs已经准备完毕可以使用了。 <br>
 Cordova的App由两部分组成，一部分是移动平台原生代码，一部分是JavaScript。当原生代码被加载的时候，一个用户定义的Loading图片会被显示出来(Splash Screen？)，JavaScript只在DOM
 加载的时候加载一次(*这里你可以很容易的写出一个模块加载JS代码来替换掉影响首页启动速度的Requirejs了*)。这也就意味着，JavaScript函数有可能在原生代码加载完成之前被执行。<br>
@@ -69,7 +69,7 @@ deviceready事件的行为和其他事件不同，其他事件的注册需要在
 	}
 ```
 
-####pause
+#### pause
 pause事件在用户把当前App放入后台的时候触发，比如切换到其他App，或者点了Home键。
 
 ```js
@@ -81,7 +81,7 @@ pause事件在用户把当前App放入后台的时候触发，比如切换到其
 ```
 Note:iOS系统下，在pause的回调函数内做任何的与Cordova APIs和原生代码之间的通信都不会被执行，直到App收到resume事件重新激活。在iOS系统resign事件是可以用来替换pause事件的，并且可以监听到锁屏按钮的事件。至于详细的内容请查询相关iOS开发的书籍吧。<br>
 
-####resume
+#### resume
 resume事件是当App从后台被调入前台的时候触发的。
 
 ```js
@@ -93,7 +93,7 @@ resume事件是当App从后台被调入前台的时候触发的。
 ```
 Note:任何函数的执行都是在pause触发以后监听到resumes事件之后进行的。需要注意的是任何在resume回调函数内执行的函数，都要通过setTimeout的方式设置0秒的延迟以后去执行。否则App会有挂起的危险。<br>
 
-####backbutton
+#### backbutton
 backbutton事件是当用户点击手机的回退按钮触发的，这个事件在现实中给诸多开发者带来了无限烦恼。这里给出一个官方的提示，重写默认的backbutton行为，注册一个事件监听backbutton事件。不在需要使用其他的函数调用的方式来覆盖backbutton的执行。
 
 ```js
@@ -104,7 +104,7 @@ backbutton事件是当用户点击手机的回退按钮触发的，这个事件�
 	}
 ```
 
-####menubutton
+#### menubutton
 menubutton事件是当用户点击手机设备的菜单按钮的时候出发的一个事件，同样也允许通过监听menubutton的方式覆盖系统默认的行为。
 
 ```js
@@ -115,7 +115,7 @@ menubutton事件是当用户点击手机设备的菜单按钮的时候出发的�
 	}
 ```
 
-####searchbutton
+#### searchbutton
 searchbutton该事件也是在按下手机设备上查找按钮的时候触发。
 
 ```js
@@ -126,9 +126,9 @@ searchbutton该事件也是在按下手机设备上查找按钮的时候触发�
 	}
 ```
 
-####startcallbutton和endcallbutton是黑莓手机的功能键，不做介绍
+#### startcallbutton和endcallbutton是黑莓手机的功能键，不做介绍
 
-####volumedownbutton & volumeupbutton
+#### volumedownbutton & volumeupbutton
 volumedownbutton&volumeupbutton是设备音量控制键被按下的时候响应的事件。
 
 ```js

--- a/01基础知识(Basic Knowledge)/08.Plugin.xml Guide(Plugin配置文件指南).md
+++ b/01基础知识(Basic Knowledge)/08.Plugin.xml Guide(Plugin配置文件指南).md
@@ -1,7 +1,7 @@
 翻译自cordova官方文档（如果需要链接，请自行对照原文链接进行查看）： 
 https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html
 
-##Plugin.xml
+## Plugin.xml
 Plugin.xml是用于设置你得插件，他包含很多元素为你的插件提供详细的设置。<br>
 ```xml
 	<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"

--- a/01基础知识(Basic Knowledge)/10.Android Plugins(Android插件开发).md
+++ b/01基础知识(Basic Knowledge)/10.Android Plugins(Android插件开发).md
@@ -1,4 +1,4 @@
-#Android 插件开发
+# Android 插件开发
 [原文地址](https://cordova.apache.org/docs/en/latest/guide/platforms/android/plugin.html "原文地址")
 Android Plugins
 ====================================================================================================
@@ -10,7 +10,7 @@ Android Plugins
 Android插件基于由android的webview来联系的Cordova-Android系统。插件被config.xml文件中的类映射来表示。插件包括一个继承自CordovaPlugin类，并重写其execute方法的java类。作为最佳实践，该插件还应该处理[暂停]（../../../cordova/events/events.pause.html）和[恢复]（../../../cordova/events/events.resume.html）事件，在插件之间传递任何消息一起。长时间运行的请求，后台活动，如媒体播放功能，监听器，或读取内部状态的插件应该同时实现onReset()方法。它会在WebView打开新页面或刷新，即重新加载的JavaScript时执行。
 
 
-##插件类映射
+## 插件类映射
 
 
 插件的JavaScript方法使用cordova.exec方法的示例如下：
@@ -33,7 +33,7 @@ Android插件基于由android的webview来联系的Cordova-Android系统。插�
 上面的service_name是JavaScript exec方法调用的service名。其中的参数值是Java类的命名空间标识。否则，插件可能编译，但仍然无法在Cordova中使用。
 
 
-##插件初始化和生命周期
+## 插件初始化和生命周期
 
 插件对象的生命周期和对应的WebView相同。但是插件只有在第一次被JavaScript调用应用的时候才会实例化，另外我们也可以在config.xml中设置onload元素为true来实例化。例如：
 
@@ -54,7 +54,7 @@ Android插件基于由android的webview来联系的Cordova-Android系统。插�
    }
 ```
 
-##写一个Android的Java插件
+## 写一个Android的Java插件
 
 
 一个JavaScript方法完成一个到原生端的插件请求，并且对应的java插件类在config.xml文件中正确映射，但是真正的Android Java Plugin类长啥样呢。最终的JavaScript的exec方法执行后都会传递到插件类中的execute方法。大部分的execute方法的实现就像下面的样子：
@@ -74,7 +74,7 @@ JavaScript的执行函数action参数对应一个类的私有方法。当捕捉�
 当捕获到异常并且返回错误，很重要的一点是尽可能的保证错误返回到与JavaScript匹配的java错误名的类。
 
 
-##Threading
+## Threading
 
 
 插件的JavaScript不在webview界面的主线程中运行，而是在WebCore线程中调用execute方法。如果需要与用户交互，你应该使用以下方式：
@@ -114,7 +114,7 @@ JavaScript的执行函数action参数对应一个类的私有方法。当捕捉�
     }
 ```
 
-##添加依赖库
+## 添加依赖库
 
 
 如果一个插件需要额外的库工作，您可以使用以下方法之一通过config.xml中添加它们：
@@ -138,7 +138,7 @@ JavaScript的执行函数action参数对应一个类的私有方法。当捕捉�
 我们建议仅当您确定相关性JAR插件是具体的，不会被其他插件使用时使用此方法，否则，就会出现平台的构建问题。
 
 
-##名为Echo的Android插件列子
+## 名为Echo的Android插件列子
 
 要匹配的JavaScript接口的echo插件在应用中描述的功能，使用plugin.xml中注入一个功能规范本地平台的config.xml文件中：
 
@@ -198,7 +198,7 @@ JavaScript的执行函数action参数对应一个类的私有方法。当捕捉�
 接下来，方法检索传递的参数，使用的是args对象的getString方法，指定第一个传递到方法的参数。当参数值传递到私有的echo方法之后，有一个参数检测方法来判断是否是空指针或者空字符串，如果出现空指针或者空字符串就会进到else中调用callbackContext.error()方法激活JavaScript的error callback方法。如果参数验证通过，则会调用callbackContext.success()方法将原来的message参数的值作为参数传递到JavaScript的success callback中
 
 
-##android的整合
+## android的整合
 
 
 android有个可以允许线程间通信的Intent系统。插件有权访问可以访问运行该应用程序在Android活动的CordovaInterface对象。这是推出一个新的Android Intent所需的上下文。所述CordovaInterface允许插件启动一个Activity，并为Intent返回到应用程序设置回调插件。
@@ -208,7 +208,7 @@ android有个可以允许线程间通信的Intent系统。插件有权访问可�
 getContext()和getActivity方法可以返回所需对象。
 
 
-##Android权限
+## Android权限
 
 
 Android权限直到最近仍被处理为安装时授权而不是运行时。要使用权限需要在应用中声明使用的权限，并且权限声明要被加入到Android Manifest文件中。这里我们可以通过使用config.xml中注入在AndroidManifest.xml文件中这些权限来完成。例子如下（读取联系人权限声明）：
@@ -219,7 +219,7 @@ Android权限直到最近仍被处理为安装时授权而不是运行时。要�
    </config-file>
 ```
 
-##Android权限（针对Cordova-Android-5.0.x以及更高版本）
+## Android权限（针对Cordova-Android-5.0.x以及更高版本）
 
 
 Android 6.0 "Marshmallow"退出了新的权限模型，使得用户可以在必要时打开和关闭权限。因此Cordova-Android 5.0的重点就是用面向未来的方式来处理权限。
@@ -311,13 +311,13 @@ switch语句将根据提示返回的requestCode判断，然后调用case中的�
 这就要求数组中指定所需的权限。这是一个提供可公开访问的权限的数组的好主意，因为这可以使插件作为依赖插件使用，虽然这不是必需的。
 
 
-##调试Android插件
+## 调试Android插件
 
 
 Android的调试可以使用Eclipse或Android Studio来完成，虽然推荐使用Android Studio。由于Cordova-Android是目前作为一个开源项目和插件都支持源代码预览，就可以像调试一个原生的Android应用程序一样调试Cordova应用程序内的Java代码。
 
 
-##启动外部Activity
+## 启动外部Activity
 
 
 在你得插件想要将Cordova放到后台然后启动新的Activity时，你需要一些特殊的考虑。当Android系统的内存过低时，就会将后台的Activity杀死。这种情况下，Cordova插件的实例也会被销毁。如果你的插件正在等待他打开的活动的结果，随着Cordova Activity被以前台方式调起，一个插件的新实例将会被创建，结果也会被获取到。然而，插件的状态不会自动保存和恢复,这样该插件的CallbackContext将会丢失。所以这里为你的Cordova插件提供了两种方式来处理这两种情况：

--- a/01基础知识(Basic Knowledge)/11.iOS Plugins(iOS插件开发).md
+++ b/01基础知识(Basic Knowledge)/11.iOS Plugins(iOS插件开发).md
@@ -1,13 +1,13 @@
 翻译自cordova官方文档（如果需要链接，请自行对照原文链接进行查看）： 
 https://cordova.apache.org/docs/en/latest/guide/platforms/ios/plugin.html
 
-###iOS开发详解
+### iOS开发详解
 
 本章节针对如何开发基于iOS系统的插件进行介绍，在此之前，请阅读[Plugin Development Guide(插件开发指南)](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/09.Plugin%20Development%20Guide(%E6%8F%92%E4%BB%B6%E5%BC%80%E5%8F%91%E6%8C%87%E5%8D%97).md)对插件的结构和JavaScript接口有一个大概的了解。<br>
 
 iOS插件是以继承至CDVPlugin类Objective-C的子类来实现的，通过JavaScript的exec函数来将service/parameter映射到Objective-C类，每一个插件在工程根目录下的config.xml文件中通过<feature>标签进行注册。<br>
 
-#####插件类的映射
+##### 插件类的映射
 我们通过如下的Cordova API来实现JavaScript到Objective-C的映射过程：
 ```sh
 	exec(<successFunction>, <failFunction>, <service>, <action>, [<args>]);
@@ -22,7 +22,7 @@ iOS插件是以继承至CDVPlugin类Objective-C的子类来实现的，通过Jav
 ```
 <feature>标签的name属性用于指定plugin在JavaScript执行exec方法时service参数的值，<action>为<feature>标签内<param>标签内value对应的Objective-C类的具体函数名，args以数组的形式传入到Objective-C函数内。<param>的name字段永远为'ios-package'。
 
-#####插件的实例化和生命周期
+##### 插件的实例化和生命周期
 plugin对象的生命周期和UIWebView是一致的，Plugin是不需要实例化的，在他们第一次被调用的时候会自动实例化。也可以通过指定<param>的方式来手动实例化一个plugin比如：
 ```xml
     <feature name="Echo">
@@ -34,7 +34,7 @@ plugin对象的生命周期和UIWebView是一致的，Plugin是不需要实例�
 
 Plugin进行耗时操作的时候，比如媒体操作，监听，或者网络状态相关的事情，应该提供重置和取消操作来终止之前的操作或者请求。当需要转入新的页面或者刷新页面这种需要重新加载JavaScript的时候被使用。<br>
 
-#####创建一个iOS plugin
+##### 创建一个iOS plugin
 JavaScript通过config.xml配置的映射来发起一个plugin请求来执行Objective-C代码，但是最终的Objective-C插件类什么样呢？下面就是plugin的一个方法定义：
 ```c
     - (void)myMethod:(CDVInvokedUrlCommand*)command
@@ -52,7 +52,7 @@ JavaScript通过config.xml配置的映射来发起一个plugin请求来执行Obj
 ```
 更多的信息可以查看CDVInvokedUrlCommand.h, CDVPluginResult.h, CDVCommandDelegate.h这三个Cordova源代码文件。<br>
 
-#####iOS CDVPluginResult类
+##### iOS CDVPluginResult类
 你可以使用CDVPluginResult类来返回各种类型的结果信息给JavaScript的回调函数，通过以下的方式来创建一个CDVPluginResult对象：
 ```c
     + (CDVPluginResult*)resultWithStatus:(CDVCommandStatus)statusOrdinal messageAs...
@@ -63,7 +63,7 @@ JavaScript通过config.xml配置的映射来发起一个plugin请求来执行Obj
 messageAsArrayBuffer以NSData的形式被传送到JavaScript回调函数，并且被转换为ArrayBuffer类型，而ArrayBuffer在传入到Objective-C端的时候会被转换成NSData。<br>
 messageAsMultipart以NSArray的形式被传入到JavaScript回调函数，里面包含各种类型的数据对象。通过这种方式传送数据，里面的数据会被序列化和反序列化，所以他可以安全的返回NSData，而不是Array/Dictionary。<br>
 
-#####Echo iOS Plugin(这篇文章对于plugin的配置在使用cordova build命令以后会被覆盖，不建议在iOS工程直接加入文件修改配置文件信息的方式添加插件。使用独立插件通过plugin add的方式添加插件比较容易维护和使用)
+##### Echo iOS Plugin(这篇文章对于plugin的配置在使用cordova build命令以后会被覆盖，不建议在iOS工程直接加入文件修改配置文件信息的方式添加插件。使用独立插件通过plugin add的方式添加插件比较容易维护和使用)
 这个例子通过plugin.xml来向指定的iOS平台注入<feature>信息。
 ```xml
     <platform name="ios">
@@ -111,10 +111,10 @@ messageAsMultipart以NSArray的形式被传入到JavaScript回调函数，里面
 ```
 上面的类继承至CDVPlugin类，在这里，Echo插件只有一个功能。就是返回JavaScript传入的第一个参数内容。如果没有传入参数则返回错误，如果传入参数，则将该参数返回。<br>
 
-#####CDVPlugin简介
+##### CDVPlugin简介
 CDVPlugin类包含其他的一些方法，你可以通过重写的方式来实现自己的行为，比如捕获pause，resume等等。具体可以去读CDVPlugin.h/CDVPlugin.m源文件<br>
 
-#####Threading
+##### Threading
 我们在plugin里面经常需要做一些耗时的操作，但是在主线程耗时过长，App就会被系统kill。所以通过runInBackground来进行耗时操作：
 ```c
     - (void)myPluginMethod:(CDVInvokedUrlCommand*)command
@@ -130,8 +130,8 @@ CDVPlugin类包含其他的一些方法，你可以通过重写的方式来实�
     }
 ```
 
-#####调试plugin
+##### 调试plugin
 使用Xcode来调试plugin，如果调试JavaScript代码，需要使用Safari在虚拟机或者设备上调试。
 
-#####易犯错误
+##### 易犯错误
 不要忘记在config.xml添加映射信息。<br>

--- a/01基础知识(Basic Knowledge)/Readme.md
+++ b/01基础知识(Basic Knowledge)/Readme.md
@@ -1,4 +1,4 @@
-##01基础知识<br>
+## 01基础知识<br>
 01.[Cordova介绍](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/01.What-is-Cordova.md) (@作者ShangXinbo)<br>
 02.[Platform Support(平台支持)](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/02.Platform%20Supports(%E5%B9%B3%E5%8F%B0%E6%94%AF%E6%8C%81).md) (@作者Ryouaki)<br>
 03.[Install Cordova(Cordova的安装)](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/03Install%20Cordova(Cordova%E7%9A%84%E5%AE%89%E8%A3%85).md) (@作者Ryouaki)<br>

--- a/02插件使用(About Plugin)/01.cordova-plugin-battery-status.md
+++ b/02插件使用(About Plugin)/01.cordova-plugin-battery-status.md
@@ -1,4 +1,4 @@
-#cordova-plugin-battery-status
+# cordova-plugin-battery-status
 
 这个插件提供了对老版本的Battery Status插件的API的支持，提供如下三个事件。<br>
 
@@ -8,18 +8,18 @@
 
 应用程序需要通过`window.addEventListener`来监听上面的事件。<br>
 
-##安装插件
+## 安装插件
 ```sh
     cordova plugin add cordova-plugin-battery-status
 ```
 
-##Status对象
+## Status对象
 所有插件事件返回的对象--status。<br>
 
 - level: 电量百分比 (0-100)。 (Number)
 - isPlugged: 一个布尔值用于判断当前设备是否接入电源。(Boolean)
 
-##batterystatus事件
+## batterystatus事件
 当电量消耗或者增加1%的时候触发，或者连接电源拿掉电源的时候出发。返回一个status对象。
 
 Example
@@ -41,7 +41,7 @@ Supported Platforms
 - Firefox OS
 - Browser (Chrome, Firefox, Opera)
 
-##batterylow事件
+## batterylow事件
 当设备电量不足，系统触发低电量警告的时候触发，这个事件是系统特有的。返回一个status对象。
 
 Example
@@ -63,7 +63,7 @@ Supported Platforms
 - Windows (Windows Phone 8.1 only)
 - Browser (Chrome, Firefox, Opera)
 
-##batterycritical事件
+## batterycritical事件
 当电量不足，触发电量危险警告的时候触发。一般在设备上设定。返回一个status对象。
 
 Example

--- a/02插件使用(About Plugin)/02.cordova-plugin-camera.md
+++ b/02插件使用(About Plugin)/02.cordova-plugin-camera.md
@@ -1,4 +1,4 @@
-#cordova-plugin-camera
+# cordova-plugin-camera
 这个插件定义了一个提供从系统库选择和取得图片的api对象`navigator.camera`。该对象只有在`deviceready`事件触发以后才可以被访问。<br>
 ```JavaScript
     document.addEventListener("deviceready", onDeviceReady, false);
@@ -7,7 +7,7 @@
     }
 ```
 
-###安装
+### 安装
 ```sh
     cordova plugin add cordova-plugin-camera
     # 老版本的cordova依然可以通过下面的命令安装，但是已经不赞成这么做了。

--- a/02插件使用(About Plugin)/18.cordova-plugin-vibration.md
+++ b/02插件使用(About Plugin)/18.cordova-plugin-vibration.md
@@ -34,7 +34,7 @@ navigator.notification.cancelVibration
 
 这个API根据参数的不同有三个不同的功能。
 
-###Standard vibrate
+### Standard vibrate
 
 振动设备持续指定的时间。
 ```js
@@ -47,7 +47,7 @@ navigator.notification.cancelVibration
 
 -__time__: 振动持续的时间，单位毫秒。 _(Number)_
 
-####例子
+#### 例子
 ```js
     // Vibrate for 3 seconds
     navigator.vibrate(3000);
@@ -55,21 +55,21 @@ navigator.notification.cancelVibration
     // Vibrate for 3 seconds
     navigator.vibrate([3000]);
 ```
-####iOS 提示
+#### iOS 提示
 
 - __time__: 忽略这个参数，振动会持续一个预设的时间。
 ```js
     navigator.vibrate(3000); // 3000 is ignored
 ```
 
-###Vibrate with a pattern (Android and Windows only)
+### Vibrate with a pattern (Android and Windows only)
 根据给定的模式振动设备。
 ```js
     navigator.vibrate(pattern);   
 ```
 - __pattern__: 振动一个给定时间段，然后停止，然后再振动，...。 _(Array of Numbers)_
 
-####例子
+#### 例子
 ```js
     // Vibrate for 1 second
     // Wait for 1 second
@@ -78,7 +78,7 @@ navigator.notification.cancelVibration
     // Vibrate for 5 seconds
     navigator.vibrate([1000, 1000, 3000, 1000, 5000]);
 ```
-###Cancel vibration (不支持iOS)
+### Cancel vibration (不支持iOS)
 直接取消当前的振动。
 ```js
     navigator.vibrate(0)

--- a/02插件使用(About Plugin)/20.cordova-plugin-whitelist.md
+++ b/02插件使用(About Plugin)/20.cordova-plugin-whitelist.md
@@ -1,10 +1,10 @@
 # cordova-plugin-whitelist
 whitelist插件是用于设置一个网络访问策略，来限制App可以访问的网络服务器，保护App。<br>
 
-##支持的平台
+## 支持的平台
 * Android 4.0.0 或以上
 
-##导航白名单
+## 导航白名单
 控制哪些URL可以被App访问，仅限顶级URL(说白了就是你访问_http://www.aaa.com/test.html_,设置_http://www.aaa.com_即可)。<br>
 
 *在Android下还可以通过iframes对非http(s)进行限制*
@@ -29,7 +29,7 @@ whitelist插件是用于设置一个网络访问策略，来限制App可以访�
     <allow-navigation href="data:*" />
 ```
 
-##外部连接白名单
+## 外部连接白名单
 控制可以打开哪些外部连接，默认是不允许打开外部连接的。
 
 *在android系统相当于发送一个BROWSEABLE的intent对象*
@@ -59,7 +59,7 @@ whitelist插件是用于设置一个网络访问策略，来限制App可以访�
          *NOT RECOMMENDED* -->
     <allow-intent href="*" />
 ```
-##网络请求白名单
+## 网络请求白名单
 控制可以请求的网络资源(images, XHRs, etc) 。
 *我们建议你使用下面的方式来指定规则，这种方式更安全。为了使用网路请求白名单我们需要在`config.xml`添加 `<access>`像下面这样：<br>
 ```xml
@@ -84,7 +84,7 @@ whitelist插件是用于设置一个网络访问策略，来限制App可以访�
 
 *Android默认可以访问https://ssl.gstatic.com/accessibility/javascript/android/*
 
-###内容安全策略(我到现在才找到这个跨域访问限制的根源T_T)
+### 内容安全策略(我到现在才找到这个跨域访问限制的根源T_T)
 控制可以访问那些网络URL(images, XHRs, etc)，在Android和iOS下，网络请求白名单不允许过滤所有类型的请求比如video和websocket，因此在附加白名单我们需要通过在网页的meta添加`Content Security Policy`。<br>
 
 在Android支持CSP，下面是一些例子。<br>
@@ -114,7 +114,7 @@ whitelist插件是用于设置一个网络访问策略，来限制App可以访�
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-src 'self' https://cordova.apache.org">
 ```
 
-###iOS9.0 above
+### iOS9.0 above
 由于iOS9.0以后对iOS App访问网络进行了限制，所以在设置白名单的同时依然要对*.plist文件进行设置：
 ```xml
     <key>NSAppTransportSecurity</key>

--- a/02插件使用(About Plugin)/Readme.md
+++ b/02插件使用(About Plugin)/Readme.md
@@ -1,4 +1,4 @@
-#插件使用<br>
+# 插件使用<br>
 00.[自定义插件](https://github.com/CordovaCn/CordovaPluginsDemo/blob/master/cordova-plugin-custom/README.md) (@作者Ryouaki)<br>
 01.[Battery Status 使用说明(电源状态)](https://github.com/CordovaCn/CordovaCn/blob/master/02%E6%8F%92%E4%BB%B6%E4%BD%BF%E7%94%A8(About%20Plugin)/01.cordova-plugin-battery-status.md) (@作者Ryouaki)<br>
 02.[Camera 使用说明(照相机)](https://github.com/CordovaCn/CordovaCn/blob/master/02%E6%8F%92%E4%BB%B6%E4%BD%BF%E7%94%A8(About%20Plugin)/02.cordova-plugin-camera.md) (@作者Ryouaki)<br>

--- a/03代码分享(Share Demo)/Readme.md
+++ b/03代码分享(Share Demo)/Readme.md
@@ -2,5 +2,5 @@
 
 *切记不要上传任何工程文件到此文件夹。*
 
-####工程文件上传：
+#### 工程文件上传：
 请在CordovaCn的team内创建自己的Repository。并将Repository的link添加到你对应的readme文件当中。

--- a/04常见问题及解决经验(Problem&Experience)/03.Git简要指南.md
+++ b/04常见问题及解决经验(Problem&Experience)/03.Git简要指南.md
@@ -1,4 +1,4 @@
-#Git使用简单指南
+# Git使用简单指南
 
 首先，在Github上创建一个Repository 以`CordovaCn`为例：https://github.com/CordovaCn/CordovaCn.git
 
@@ -17,64 +17,64 @@
 我们需要将这两个文件转移到`~/.ssh/`目录下面。然后登录`Github`，在个人`settings`里面的`ssh keys`里面把`id_rsa.pub`文件的内容添加进去。<br>
 *切记，如果是private的repository，需要执行如下命令`ssh-add ~/.ssh/id_rsa`。*
 
-###clone
+### clone
 通过clone命令来将远端服务器上的资源拉到本地。
 ```sh
     $ git clone <版本库的网址>
     # 记得建立一个新的文件夹然后cd进去。
 ```
 
-###remote
+### remote
 通过remote指令列出主机名
 ```sh
     $ git remote
     origin   # 主机名
 ```
 
-###fetch
+### fetch
 通过fetch指令来检查远程库的master是否有更新
 ```sh
     $ git fetch origin master
 ```
 
-###checkout
+### checkout
 通过下面指令来以master为基础创建一个新的分支
 ```sh
     $ git checkout -b newBrach origin/master
 ```
 
-###merge
+### merge
 合并分支
 ```sh
     $ git merge origin/master
     # 在当前目录的分支合并origin/master
 ```
 
-###pull
+### pull
 将远端的next分支合并到本地的master分支上。
 ```sh
     $ git pull origin next:master 
 ```
 
-###add
+### add
 将本地变更添加到index
 ```sh
     $ git add <文件目录> or 文件路径
 ```
 
-###commit
+### commit
 提交变更到本地库,也就是将add的内容添加到本地库里面
 ```sh
     $ git commit -m <log message>
 ```
 
-###push
+### push
 推送到远端origin主机master分支上，将commit的内容推到origin的master分支上。
 ```sh
     $ git push origin master
 ```
 
-###放弃本地变更，从master覆盖本地分支
+### 放弃本地变更，从master覆盖本地分支
 ```sh
     git fetch --all
     git reset --hard origin/master

--- a/04常见问题及解决经验(Problem&Experience)/05.Android调试方法.md
+++ b/04常见问题及解决经验(Problem&Experience)/05.Android调试方法.md
@@ -1,10 +1,10 @@
-#Cordova Android调试技巧
+# Cordova Android调试技巧
 Cordova Android调试主要分两部分：<br>
 
 - Java (*插件原生代码，自定义插件，高性能代码*)
 - JavaScript/CSS/HTML (*UI界面，插件JS api接口*)
 
-##调试环境及工具
+## 调试环境及工具
 
 - 系统Mac OS X (*其他系统都差不多*)
 - 工具 Eclipse+ADT (*这里强烈建议使用ADT相关工具比如Android Studio或者Eclipse+ADT，可以帮你避免很多很多麻烦*)
@@ -12,7 +12,7 @@ Cordova Android调试主要分两部分：<br>
 - Android 手机(*推荐Android4.4以上版本，自行百度如何开启USB调试模式*)
 - 手机数据线(*其实我觉得这是废话。。。。。。。。*)
 
-##Java调试 (*和原生开发调试是一样的*)
+## Java调试 (*和原生开发调试是一样的*)
 使用Eclipse导入工程(*CordovaLib/MainActivity*)。一般目录在Cordova根目录/Platforms/Android下。<br>
 ![](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/Screen%20Shot%202016-03-21%20at%20%E4%B8%8B%E5%8D%887.42.41.png)
 <br>
@@ -26,7 +26,7 @@ Cordova Android调试主要分两部分：<br>
 <br>
 (*具体请百度Android调试。*)
 
-##JavaScript/CSS/HTML (*和Web前端调试是一样的*)
+## JavaScript/CSS/HTML (*和Web前端调试是一样的*)
 首先需要确定的一点是你能连接google，因为chrome调试手机JS需要连接远程JS(很蛋疼的)。<br>
 USB连接手机，运行App(记得手机要信任PC)，启动App，打开Chrome，地址栏输入`chrome://inspect/#devices`<br>
 ![](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/Screen%20Shot%202016-03-21%20at%20%E4%B8%8B%E5%8D%888.02.33.png)
@@ -36,5 +36,5 @@ USB连接手机，运行App(记得手机要信任PC)，启动App，打开Chrome�
 <br>
 (*请自行脑补如何使用Web Inspector*)
 
-##参考(*这个人写的比较仔细，就是版本有点老了。现在有少许变化。*)
+## 参考(*这个人写的比较仔细，就是版本有点老了。现在有少许变化。*)
 [移动端Web开发调试之Chrome远程调试(Remote Debugging)](http://blog.csdn.net/freshlover/article/details/42528643)

--- a/04常见问题及解决经验(Problem&Experience)/06.iOS调试方法.md
+++ b/04常见问题及解决经验(Problem&Experience)/06.iOS调试方法.md
@@ -1,10 +1,10 @@
-#Cordova iOS调试技巧
+# Cordova iOS调试技巧
 Cordova iOS调试主要分两部分：<br>
 
 - Objective-C (插件原生代码，自定义插件，高性能代码)
 - JavaScript/CSS/HTML (UI界面，插件JS api接口)
 
-##调试环境及工具
+## 调试环境及工具
 
 - 系统Mac OS X
 - 工具 XCode
@@ -12,7 +12,7 @@ Cordova iOS调试主要分两部分：<br>
 - iPhone 手机(联机调试需要，SDK要求9.0以上或者低于9.0但是有付费开发者证书)
 - 手机数据线(其实我觉得这是废话。。。。。。。。)
 
-##Objective-C调试 (和原生开发调试是一样的)
+## Objective-C调试 (和原生开发调试是一样的)
 使用XCode打开工程，选择你要调试的代码文件，设置断点。<br>
 ![](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/Screen%20Shot%202016-03-19%20at%20%E4%B8%8B%E5%8D%8812.04.07.png)
 使用command+R开始运行调试。下面是进入Debug断点以后的界面<br>
@@ -28,14 +28,14 @@ Cordova iOS调试主要分两部分：<br>
 - 跳出函数
 - 其他 (*后面的自己百度吧，不常用，我好少打点字去解释。*)
 
-##JavaScript/CSS/HTML (和Web前端调试是一样的)
+## JavaScript/CSS/HTML (和Web前端调试是一样的)
 首先打开Safari -> Preferences -> Advanced -> Show Develop menu in menu bar 打勾。<br>
 ![](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/Screen%20Shot%202016-03-19%20at%20%E4%B8%8B%E5%8D%8812.12.52.png)
 command+R启动虚拟机当程序运行后。切换回safari。选择菜单 -> Develop -> Simulator ->对应程序的html。<br>
 ![](https://github.com/CordovaCn/CordovaCn/blob/master/imgs/Screen%20Shot%202016-03-19%20at%20%E4%B8%8B%E5%8D%8812.15.41.png)
 (*请自行脑补如何使用Web Inspector*)
 
-##联机调试
+## 联机调试
 联机Objective-C调试，与虚拟机调试是一样的。不需要额外讲解。<br>
 联机JavaScript/CSS/HTML调试，需要在手机上进行如下设置：<br>
 打开Settings -> Safari -> Advanced -> Web Inspector 打开<br>

--- a/05经验博文(Blog for Cordova)/02-Mar-2016 Cordova iOS 4.1.0 Released.md
+++ b/05经验博文(Blog for Cordova)/02-Mar-2016 Cordova iOS 4.1.0 Released.md
@@ -1,5 +1,5 @@
-#Cordova iOS 4.1.0 
-###By: Steve Gill(02 Mar 2016)
+# Cordova iOS 4.1.0 
+### By: Steve Gill(02 Mar 2016)
 [原文连接](https://cordova.apache.org/announcements/2016/03/02/ios-4.1.0.html)
 
 我们非常高兴的宣布Cordova iOS 4.1.0正式发布了.
@@ -8,12 +8,12 @@
 在新的Cordova-cli版本中,当用户使用Cordova platform add/update的时候,会将Cordova-iOS@4.1.0作为默认版本.
 如果你现在就想用iOS@4.1.0,那么在使用Cordova platform add/update的时候记得指定版本号.
 
-#####现有工程升级
+##### 现有工程升级
 ```sh
 cordova platform update ios@4.1.0
 ```
 
-#####在新项目中使用
+##### 在新项目中使用
 ```sh
 cordova platform add ios@4.1.0
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-#CordovaCn 提交规则 Ver 1.0<br>
+# CordovaCn 提交规则 Ver 1.0<br>
 
 - 01 基础知识 主要提供官方使用手册相关内容(以Android和iOS为主)<br>
 - 02 插件使用 主要提供各种插件的使用说明类文章，比如插件Readme的翻译以及api使用经验<br>
@@ -7,14 +7,14 @@
 - 05 学习和参考资料(Blog or Referance) 分享网络上Cordova相关资料<br>
 - 06 imgs     用于提交Readme关联的图片<br>
 
-#####所有站内信息一定要提交后在本页添加一个link到你对应的*.md文件上或者是Demo首页
+##### 所有站内信息一定要提交后在本页添加一个link到你对应的*.md文件上或者是Demo首页
 本站内容提交方式    标题 link(@作者XXX)<br>
 本站外内容提交方式  标题 link(转@作者XXX)<br>
 Example: <br>
 01.[GitHub上README.md教程](http://blog.csdn.net/kaitiren/article/details/38513715) (转@作者kaitiren)<br>
 02.[Github简要指南](https://github.com/CordovaCn/CordovaCn/blob/master/04%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E5%8F%8A%E8%A7%A3%E5%86%B3%E7%BB%8F%E9%AA%8C(Problem&Experience)/03.Git%E7%AE%80%E8%A6%81%E6%8C%87%E5%8D%97.md) (@作者Ryouaki)<br>
 <br>
-##01基础知识<br>
+## 01基础知识<br>
 01.[Cordova介绍](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/01.What-is-Cordova.md) (@作者ShangXinbo)<br>
 02.[Platform Support(平台支持)](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/02.Platform%20Supports(%E5%B9%B3%E5%8F%B0%E6%94%AF%E6%8C%81).md) (@作者Ryouaki)<br>
 03.[Install Cordova(Cordova的安装)](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/03Install%20Cordova(Cordova%E7%9A%84%E5%AE%89%E8%A3%85).md) (@作者Ryouaki)<br>
@@ -32,7 +32,7 @@ Example: <br>
 14.[Android WebViews](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/14.Android%20Webview(Android%E5%B5%8C%E5%85%A5%E5%BC%8FWebview).md) (@作者Ryouaki)<br>
 15.[iOS WebViews](https://github.com/CordovaCn/CordovaCn/blob/master/01%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86(Basic%20Knowledge)/15.iOS%20Webview(iOS%E5%B5%8C%E5%85%A5%E5%BC%8FWebview).md) (@作者Ryouaki)<br>
 
-#02插件使用<br>
+# 02插件使用<br>
 00.[自定义插件](https://github.com/CordovaCn/CordovaPluginsDemo/blob/master/cordova-plugin-custom/README.md) (@作者Ryouaki)<br>
 01.[Battery Status 使用说明(电源状态)](https://github.com/CordovaCn/CordovaCn/blob/master/02%E6%8F%92%E4%BB%B6%E4%BD%BF%E7%94%A8(About%20Plugin)/01.cordova-plugin-battery-status.md) (@作者Ryouaki)<br>
 02.[Camera 使用说明(照相机)](https://github.com/CordovaCn/CordovaCn/blob/master/02%E6%8F%92%E4%BB%B6%E4%BD%BF%E7%94%A8(About%20Plugin)/02.cordova-plugin-camera.md) (@作者Ryouaki)<br>
@@ -56,7 +56,7 @@ Example: <br>
 20.[Whitelist 使用说明(白名单)](https://github.com/CordovaCn/CordovaCn/blob/master/02%E6%8F%92%E4%BB%B6%E4%BD%BF%E7%94%A8(About%20Plugin)/20.cordova-plugin-whitelist.md) (@作者Ryouaki)<br>
 21.[Cordova-Plugin-Photos (获取多图插件)](https://github.com/ryouaki/Cordova-Plugin-Photos/blob/master/README.md) (@作者Ryouaki)<br>
 <br>
-##03代码分享<br>
+## 03代码分享<br>
 *请在CordovaCn创建单独的Repository然后将连接Link到这里*<br>
 00.[自定义插件Demo](https://github.com/CordovaCn/CordovaPluginsDemo) (@作者Ryouaki)<br>
 01.[Battery Status Demo](https://github.com/CordovaCn/CordovaPluginsDemo) (@作者Ryouaki)<br>
@@ -71,7 +71,7 @@ Example: <br>
 23.[基于Hybrid的原生混合Demo(Android)，实现JS与原生相互通信](https://github.com/CordovaCn/WebviewBridge) (@作者杭州-毛毛熊)<br>
 24.[安卓应用软件自动更新Android App(Android)](https://github.com/vaenow/cordova-plugin-app-update) (@作者Vaenow)<br>
 <br>
-##04常见问题及解决办法<br>
+## 04常见问题及解决办法<br>
 01.[iOS域访问限制(statusCode==0)](https://github.com/CordovaCn/CordovaCn/blob/master/04%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E5%8F%8A%E8%A7%A3%E5%86%B3%E7%BB%8F%E9%AA%8C(Problem&Experience)/01.iOS%E5%9F%9F%E8%AE%BF%E9%97%AE%E9%99%90%E5%88%B6(Ajax%E8%AF%B7%E6%B1%82%E8%BF%94%E5%9B%9EstatusCode==0).md) (@作者Ryouaki)<br>
 02.[长按屏幕引起的提示菜单或者提示框问题](https://github.com/CordovaCn/CordovaCn/blob/master/04%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E5%8F%8A%E8%A7%A3%E5%86%B3%E7%BB%8F%E9%AA%8C(Problem%26Experience)/02.%E9%95%BF%E6%8C%89%E5%B1%8F%E5%B9%95%E5%BC%95%E8%B5%B7%E7%9A%84%E6%8F%90%E7%A4%BA%E8%8F%9C%E5%8D%95%E6%88%96%E8%80%85%E6%8F%90%E7%A4%BA%E6%A1%86%E9%97%AE%E9%A2%98.md) (@作者Ryouaki)<br>
 03.[Git简要指南](https://github.com/CordovaCn/CordovaCn/blob/master/04%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E5%8F%8A%E8%A7%A3%E5%86%B3%E7%BB%8F%E9%AA%8C(Problem%26Experience)/03.Git%E7%AE%80%E8%A6%81%E6%8C%87%E5%8D%97.md) (@作者Ryouaki)<br>
@@ -92,7 +92,7 @@ Example: <br>
 18.[iOS-IPA-Release企业appcenter架设](http://blog.csdn.net/zrh1121/article/details/52671529)  (@作者深圳-华)<br>
 19.[解决Input type="search"移动设备弹出键盘不显示search类型键盘](https://github.com/CordovaCn/CordovaCn/blob/master/04%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E5%8F%8A%E8%A7%A3%E5%86%B3%E7%BB%8F%E9%AA%8C(Problem&Experience)/19.%E8%A7%A3%E5%86%B3Input%20type=%22search%22%E7%A7%BB%E5%8A%A8%E8%AE%BE%E5%A4%87%E5%BC%B9%E5%87%BA%E9%94%AE%E7%9B%98%E4%B8%8D%E6%98%BE%E7%A4%BAsearch%E7%B1%BB%E5%9E%8B%E9%94%AE%E7%9B%98.md) (@作者Ryouaki)
 <br>
-##05学习和参考资料(Blog or Referance)<br>
+## 05学习和参考资料(Blog or Referance)<br>
 01.[Cordova iOS4.1.0 Released](https://github.com/CordovaCn/CordovaCn/blob/master/05%E5%AE%98%E6%96%B9%E5%8D%9A%E6%96%87(Blog%20from%20Cordova)/02-Mar-2016%20Cordova%20iOS%204.1.0%20Released.md) (@作者Ryouaki)<br>
 02.[JavaScript学习资料](http://www.runoob.com/js/js-tutorial.html) (转@菜鸟教程)<br>
 03.[CSS学习资料](http://www.runoob.com/css/css-tutorial.html) (转@菜鸟教程)<br>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
